### PR TITLE
yar_client without timeout, if server timeout, and tv will be set to 0, ...

### DIFF
--- a/yar_client.h
+++ b/yar_client.h
@@ -29,6 +29,7 @@ struct _yar_client {
 	int fd;
 	char *hostname;
 	int persistent;
+	int timeout;
 	yar_client_call call;
 };
 


### PR DESCRIPTION
#### Cause:

yar client select 超时默认是1s，如果server 超时，tv会被重置为0, select就会死循环, 导致yar client不可用。
#### Mod:

yar client 不永久等待，可以设置超时时间。
#### man select 解释:

> On  Linux,  select() modifies timeout to reflect the amount of time not slept; most other implementations do not do this.  (POSIX.1-2001 permits either behaviour.)  This causes problems both when Linux code which reads  timeout  is ported  to  other  operating  systems,  and  when code is ported to Linux that reuses a struct timeval for multiple select()s in a loop without reinitializing it.  Consider timeout to be undefined after 
> select() returns."""
